### PR TITLE
Address compiler warnings

### DIFF
--- a/include/dragonbox/dragonbox.h
+++ b/include/dragonbox/dragonbox.h
@@ -203,7 +203,7 @@ namespace jkj::dragonbox {
 		carrier_uint u;
 
 		ieee754_bits() = default;
-		constexpr explicit ieee754_bits(carrier_uint u) noexcept : u{ u } {}
+		constexpr explicit ieee754_bits(carrier_uint u_) noexcept : u{ u_ } {}
 		constexpr explicit ieee754_bits(T x) noexcept : u{ ieee754_traits<T>::float_to_carrier(x) } {}
 
 		constexpr T to_float() const noexcept {
@@ -657,7 +657,7 @@ namespace jkj::dragonbox {
 				for (int i = 1; i < bit_width; ++i) {
 					mod_inverse = mod_inverse * mod_inverse * a;
 				}
-				if (bit_width < value_bits<UInt>) {
+				if (unsigned(bit_width) < value_bits<UInt>) {
 					auto mask = UInt((UInt(1) << bit_width) - 1);
 					return UInt(mod_inverse & mask);
 				}
@@ -696,7 +696,7 @@ namespace jkj::dragonbox {
 				}();
 			};
 
-			template <std::size_t table_size, class UInt>
+			template <int table_size, class UInt>
 			constexpr bool divisible_by_power_of_5(UInt x, unsigned int exp) noexcept {
 				auto const& table = table_holder<UInt, 5, table_size>::table;
 				assert(exp < (unsigned int)(table.size));
@@ -2110,7 +2110,7 @@ namespace jkj::dragonbox {
 					static constexpr auto tag = tag_t::away_from_zero;
 
 					template <class Fp>
-					static constexpr void break_rounding_tie(Fp& fp) noexcept {}
+					static constexpr void break_rounding_tie(Fp& /*fp*/) noexcept {}
 				};
 
 				struct toward_zero : base {


### PR DESCRIPTION
Hi
Here are a few changes that would silence some compiler diagnostics which are common when warnings are elevated.
Thanks
John

g++ 10.2.0 ([settings](https://github.com/johnmcfarlane/cnl/blob/main/test/toolchain/gcc.cmake)):
- dragonbox.h:206:48: error: declaration of ‘u’ shadows a member of ‘jkj::dragonbox::ieee754_bits<T>’ [-Werror=shadow]
- dragonbox.h:701:57: error: conversion from ‘long unsigned int’ to ‘int’ may change value [-Werror=conversion]
- dragonbox.h:660:19: error: comparison of integer expressions of different signedness: ‘int’ and ‘const size_t’ {aka ‘const long unsigned int’} [-Werror=sign-compare]

clang 11.0.0 ([settings](https://github.com/johnmcfarlane/cnl/blob/main/test/toolchain/clang.cmake)):
- dragonbox.h:2113:51: error: unused parameter 'fp' [-Werror,-Wunused-parameter]