### PR TITLE
Add CI support for OSes and other architectures.

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -1,0 +1,53 @@
+name: Cross-Compilation CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [master]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          # Test big and little-endian architectures, 32-bit and 64-bit
+          - arm64-unknown-linux-gnu
+          - arm64eb-unknown-linux-gnu
+          - mipsel-unknown-linux-gnu
+          - mips-unknown-linux-gnu
+          - riscv64-unknown-linux-gnu
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install xcross==0.1.7
+
+      - name: Configure
+        run: xcross --target ${{ matrix.target }}
+          cmake -Ssubproject/test -Bbuild/test
+          -DCMAKE_BUILD_TYPE:STRING=Debug
+
+      - name: Build
+        run: xcross --target ${{ matrix.target }}
+          cmake --build build/test --config Debug
+
+      - name: Test
+        run: |
+          cd build/test
+          xcross --target ${{ matrix.target }} run ./verify_fast_multiplication
+          xcross --target ${{ matrix.target }} run ./verify_log_computation
+          xcross --target ${{ matrix.target }} run ./verify_magic_division
+          xcross --target ${{ matrix.target }} run ./test_all_shorter_interval_cases
+          xcross --target ${{ matrix.target }} run ./uniform_random_test
+          xcross --target ${{ matrix.target }} run ./verify_compressed_cache
+          xcross --target ${{ matrix.target }} run ./compute_required_cache_length

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -1,0 +1,27 @@
+name: OS Continuous Integration
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [master]
+
+jobs:
+  cross:
+    name: DragonBox ${{matrix.platform}}
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Configure
+      run: cmake -Ssubproject/test -Bbuild/test -DCMAKE_BUILD_TYPE:STRING=Debug
+
+    - name: Build
+      run: cmake --build build/test --config Debug
+
+    - name: Test
+      run: |
+        cd build/test
+        ctest -C Debug --output-on-failure


### PR DESCRIPTION
Adds CI support for macOS and Windows, 64-bit ARM big and little-endian, 32-bit MIPS big and little-endian, and 64-bit RISC-V. I tried to avoid using my own project, [xcross](https://github.com/Alexhuszagh/xcross) for this, but Dockcross doesn't seem to to support any big-endian, 64-bit targets, and `zig cc` currently has issues with some C++ code. I'm more than happy to switch to Dockcross if that's not required.

The builds are not run automatically for commits to the repository, however, they are run on PRs and when manually desired. This closes #20.

The actions for dockcross would be quite simple as well:

```bash
# Configure Dockcross
git clone https://github.com/dockcross/dockcross
cd dockcross
echo "docker run --rm dockcross/linux-armv7" > dockcross
chmod +x dockcross

# Build project
./dockcross cmake -Ssubproject/test -Bbuild/test -DCMAKE_BUILD_TYPE:STRING=Debug
./dockcross cmake --build build/test --config Debug

# Run tests
cd build/test
./dockcross qemu-arm ./verify_fast_multiplication
./dockcross qemu-arm ./verify_log_computation
./dockcross qemu-arm ./verify_magic_division
./dockcross qemu-arm ./test_all_shorter_interval_cases
./dockcross qemu-arm ./uniform_random_test
./dockcross qemu-arm ./verify_compressed_cache
./dockcross qemu-arm ./compute_required_cache_length
```

Note that the Qemu runner would change for each, so we'd also need to store that additionally in the matrix.