### PR TITLE
update actions/checkout in GitHub Actions to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - uses: friendlyanon/fetch-core-count@v1
         id: cores
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - uses: friendlyanon/fetch-core-count@v1
         id: cores
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
 
       - uses: friendlyanon/fetch-core-count@v1
         id: cores

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -21,7 +21,7 @@ jobs:
           - riscv64-unknown-linux-gnu
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Configure
       run: cmake -Ssubproject/test -Bbuild/test -DCMAKE_BUILD_TYPE:STRING=Debug
 


### PR DESCRIPTION
Updates the `actions/checkout` actions used in the GitHub Actions workflow to its newest version.

Changes in [actions/checkout](https://github.com/actions/checkout) can be seen here: https://github.com/actions/checkout/blob/main/CHANGELOG.md

As far as I can tell this should be backwards compatible, so I do not expect any breakage.