### PR TITLE
Fix header installation path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ option(DRAGONBOX_INSTALL_TO_CHARS
         On)
 
 set(dragonbox_directory "dragonbox-${PROJECT_VERSION}")
-set(dragonbox_include_directory "${CMAKE_INSTALL_INCLUDEDIR}/${dragonbox_directory}")
+set(dragonbox_include_directory "${CMAKE_INSTALL_INCLUDEDIR}")
 set(dragonbox_install_targets "dragonbox")
 
 if (DRAGONBOX_INSTALL_TO_CHARS)


### PR DESCRIPTION
Do not install the headers in /usr/include/dragonbox-1.1.3/dragonbox but install them in /usr/include/dragonbox.