### PR TITLE
Remove some C style casts

### DIFF
--- a/include/dragonbox/dragonbox.h
+++ b/include/dragonbox/dragonbox.h
@@ -135,8 +135,8 @@ namespace jkj::dragonbox {
             constexpr int exponent_bits = format::exponent_bits;
             static_assert(detail::value_bits<unsigned int> > exponent_bits);
             constexpr auto exponent_bits_mask =
-                (unsigned int)(((unsigned int)(1) << exponent_bits) - 1);
-            return (unsigned int)(u >> significand_bits) & exponent_bits_mask;
+                (static_cast<unsigned int>(1) << exponent_bits) - 1;
+            return static_cast<unsigned int>(u >> significand_bits) & exponent_bits_mask;
         }
 
         // Extract significand bits from a bit pattern.


### PR DESCRIPTION
My project uses GCC and has -Werror and -Wold-style-cast compiler options set to catch bad pointer casting practices. While the lines I've changed aren't necessarily bad usage of the old style cast, the are collateral damage in the war against bugs.  I'm only using dragonbox.h in my project so other files haven't been changed.

Thanks for a great library.