### PR TITLE
Constexpr to_decimal

### DIFF
--- a/include/dragonbox/dragonbox.h
+++ b/include/dragonbox/dragonbox.h
@@ -1871,6 +1871,11 @@ namespace jkj::dragonbox {
                 //////////////////////////////////////////////////////////////////////
 
                 ReturnType ret_value;
+                if (cpp20_and_in_constexpr()) {
+                  // TODO: In runtime we return with the sign remaning uninitialized, which is technically UB
+                  // We work around this in constexpr, but probably needs fixing in general
+                  ret_value = {};
+                }
                 IntervalType interval_type{additional_args...};
 
                 // Compute k and beta.
@@ -2021,6 +2026,11 @@ namespace jkj::dragonbox {
             compute_nearest_shorter(int const exponent,
                                     AdditionalArgs... additional_args) noexcept {
                 ReturnType ret_value;
+                if (cpp20_and_in_constexpr()) {
+                  // TODO: In runtime we return with the sign remaning uninitialized, which is technically UB
+                  // We work around this in constexpr, but probably needs fixing in general
+                  ret_value = {};
+                }
                 IntervalType interval_type{additional_args...};
 
                 // Compute k and beta.
@@ -2081,6 +2091,11 @@ namespace jkj::dragonbox {
                 //////////////////////////////////////////////////////////////////////
 
                 ReturnType ret_value;
+                if (cpp20_and_in_constexpr()) {
+                  // TODO: In runtime we return with the sign remaning uninitialized, which is technically UB
+                  // We work around this in constexpr, but probably needs fixing in general
+                  ret_value = {};
+                }
 
                 // Compute k and beta.
                 int const minus_k = log::floor_log10_pow2(exponent) - kappa;
@@ -2172,6 +2187,11 @@ namespace jkj::dragonbox {
                 //////////////////////////////////////////////////////////////////////
 
                 ReturnType ret_value;
+                if (cpp20_and_in_constexpr()) {
+                  // TODO: In runtime we return with the sign remaning uninitialized, which is technically UB
+                  // We work around this in constexpr, but probably needs fixing in general
+                  ret_value = {};
+                }
 
                 // Compute k and beta.
                 int const minus_k =

--- a/subproject/test/CMakeLists.txt
+++ b/subproject/test/CMakeLists.txt
@@ -68,3 +68,8 @@ add_test(verify_compressed_cache)
 add_test(verify_fast_multiplication)
 add_test(verify_log_computation)
 add_test(verify_magic_division)
+add_test(constexpr)
+set_target_properties(constexpr PROPERTIES
+  CXX_STANDARD 20
+  CXX_STANDARD_REQUIRED ON
+)

--- a/subproject/test/CMakeLists.txt
+++ b/subproject/test/CMakeLists.txt
@@ -68,8 +68,12 @@ add_test(verify_compressed_cache)
 add_test(verify_fast_multiplication)
 add_test(verify_log_computation)
 add_test(verify_magic_division)
-add_test(constexpr)
-set_target_properties(constexpr PROPERTIES
-  CXX_STANDARD 20
-  CXX_STANDARD_REQUIRED ON
-)
+
+option(DRAGONBOX_ENABLE_CONSTEXPR_TEST "Build constexpr test" OFF)
+if (DRAGONBOX_ENABLE_CONSTEXPR_TEST)
+    add_test(constexpr)
+    set_target_properties(constexpr PROPERTIES
+      CXX_STANDARD 20
+      CXX_STANDARD_REQUIRED ON
+    )
+endif()

--- a/subproject/test/source/constexpr.cpp
+++ b/subproject/test/source/constexpr.cpp
@@ -1,0 +1,15 @@
+#include "dragonbox/dragonbox.h"
+
+constexpr auto x = jkj::dragonbox::to_decimal(3.1415);
+static_assert(x.significand == 31415);
+static_assert(x.exponent == -4);
+static_assert(!x.is_negative);
+
+constexpr auto y = jkj::dragonbox::to_decimal(123.);
+static_assert(y.significand == 123);
+static_assert(y.exponent == 0);
+static_assert(!y.is_negative);
+
+int main() {
+    return 0;
+}


### PR DESCRIPTION
Related: https://github.com/jk-jeon/dragonbox/issues/41

Attempt to make `to_decimal` constexpr when compiled in C++20. Added some smoke tests, a more comprehensive set of constexpr tests would be needed.