### PR TITLE
Minor compatibility fixup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-﻿# TODO: clean
+# TODO: clean
 
 # VS generated CMake settings
 CMakeSettings.json
@@ -51,6 +51,9 @@ build/
 # .idea/modules
 # *.iml
 # *.ipr
+
+# Qt Creator
+build-*/
 
 # CMake
 cmake-build-*/

--- a/include/dragonbox/dragonbox.h
+++ b/include/dragonbox/dragonbox.h
@@ -1725,7 +1725,7 @@ namespace jkj {
 #endif
 
             // Compressed cache.
-            template <class FloatFormat, class Dummy = void>
+            template <class FloatFormat = ieee754_binary64, class Dummy = void>
             struct compressed_cache_detail;
 
             template <class Dummy>

--- a/include/dragonbox/dragonbox.h
+++ b/include/dragonbox/dragonbox.h
@@ -607,8 +607,10 @@ namespace jkj {
                             return *this;
                         }
 #if JKJ_HAS_BUILTIN(__builtin_addcll)
-                        static_assert(stdr::is_same<unsigned long long, stdr::uint_least64_t>::value &&
-                                      value_bits<stdr::uint_least64_t>::value == 64);
+                        static_assert(
+                            (std::numeric_limits<unsigned long long>::max() ==
+                                std::numeric_limits<stdr::uint_least64_t>::max()) &&
+                            value_bits<stdr::uint_least64_t>::value == 64);
                         unsigned long long carry{};
                         low_ = __builtin_addcll(low_, n, 0, &carry);
                         high_ = __builtin_addcll(high_, 0, carry, &carry);


### PR DESCRIPTION
Changed two things:

- CLang/ARM64 can't quite resolve `unsigned long long` == `unsigned long` despite them both being 64-bit unsigned integers.  Comparing those two via numeric limits now
- Presumed a default parameter for `compressed_cache_detail` of `ieee754_binary64`.  If I got that wrong, my feelings won't be hurt and you can reject the PR :) 