### PR TITLE
Maybe fix bug in `remove_trailing_zeros(u64)`

### DIFF
--- a/include/dragonbox/dragonbox.h
+++ b/include/dragonbox/dragonbox.h
@@ -3004,7 +3004,7 @@ namespace jkj {
                 significand = b ? r : significand;
 
                 r = detail::bits::rotr<64>(
-                    detail::stdr::uint_least64_t(significand * UINT32_C(14757395258967641293)), 1);
+                    detail::stdr::uint_least64_t(significand * UINT64_C(14757395258967641293)), 1);
                 b = r < UINT64_C(1844674407370955162);
                 s = s * 2 + b;
                 significand = b ? r : significand;


### PR DESCRIPTION
Not sure if this was a typo or not, but seems like might be given that the integer wouldn't fit into a `u32`. If this is not a typo and was intentional, I'd be interested to understand the reasoning behind it.

Even if this is a typo, it does not appear to have any visible impact on the behavior. At least on my compiler (Clang, macOS), the UINT32_C macro applied to integers that are too large to fit in 32 bits still seems to produce values of type `unsigned long`, which is 64 bits on my compiler. I don't know if there are other compilers where this indeed results in a bug.