### PR TITLE
update actions/checkout to v4 + actions/setup-python to v5 in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: friendlyanon/fetch-core-count@v1
         id: cores
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: friendlyanon/fetch-core-count@v1
         id: cores
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: friendlyanon/fetch-core-count@v1
         id: cores

--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -25,11 +25,11 @@ jobs:
           - riscv64-unknown-linux-gnu
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.12
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -10,7 +10,7 @@ jobs:
     name: DragonBox ${{matrix.platform}}
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest, windows-2025]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/os.yml
+++ b/.github/workflows/os.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Configure
       run: cmake -Ssubproject/test -Bbuild/test -DCMAKE_BUILD_TYPE:STRING=Debug
 


### PR DESCRIPTION
Updates the `actions/checkout` and ' actions/setup-python` actions used in the GitHub Actions workflows to their newest versions.

* Changes in [actions/checkout](https://github.com/actions/checkout) can be seen here: https://github.com/actions/checkout/blob/main/CHANGELOG.md
* Changes in [actions/setup-python](https://github.com/actions/setup-python) can be seen here: https://github.com/actions/setup-python/releases

The update gets rid of some GitHub Actions warnings like those seen here: https://github.com/jk-jeon/dragonbox/actions/runs/11561967195

> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/setup-python@v2. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
> The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-python@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

As far as I can tell this should be backwards compatible, so I do not expect any breakage.

**Edit:** I also had to update the Python version from 3.7 to 3.12, because some jobs failed with the message
```
Version 3.7 was not found in the local cache
  Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
  The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
```